### PR TITLE
Set minimizeJar to false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <minimizeJar>true</minimizeJar>
+                            <minimizeJar>false</minimizeJar>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Apparently one of JDA's libs involves a lot of reflection and therefore minimizeJar breaks things. On a positive note it did make the jar smaller by 4mb. Let's disable it for now until someone sorts out which dependencies can and cannot be minimized.